### PR TITLE
ci: add simple continuous integration with repoman

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  repoman:
+    runs-on: ubuntu-latest
+    container: gentoo/stage3:amd64-systemd
+    steps:
+    - uses: actions/checkout@v2
+    - name: install portage
+      run: emerge-webrsync
+    - name: install repoman
+      run: emerge app-portage/repoman
+    - name: repoman checks
+      run: repoman -x full


### PR DESCRIPTION
I am trying to update corectl to 1.2.1 by myself but I found out there are some warnings pointed by repoman.

I just wanted to share my continuous integration pipeline with you to improve ebuild quality.

you can see it here:
https://github.com/mercuriete/portage-overlay/runs/3782916826

partial output:
```
   kde-misc/corectrl/corectrl-1.0.7-r1.ebuild: line 46: Ebuild contains leading spaces
   kde-misc/corectrl/corectrl-1.1.0-r1.ebuild: line 46: Ebuild contains leading spaces
   kde-misc/corectrl/corectrl-1.1.1-r1.ebuild: line 47: Ebuild contains leading spaces
   kde-misc/corectrl/corectrl-1.1.3.ebuild: line 47: Ebuild contains leading spaces
   kde-misc/corectrl/corectrl-9999.ebuild: line 45: Ebuild contains leading spaces
```


:)
